### PR TITLE
Add live event tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 
+env:
+  - CXX=g++-4.9
+
 node_js:
   - 5.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: node_js
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+
 env:
   - CXX=g++-4.9
 

--- a/conf/config.json.example
+++ b/conf/config.json.example
@@ -12,6 +12,8 @@
   "wsConfig": {
       "port": 8082
   },
+  "wsUrl": "ws://localhost:8082/",
+  "wsUiConfig": { "timeout": 250, "editLogEvents": {"wikiedits":1} },
 
   "//": "For unit testing (WILL BE DROPPED AND RECREATED)",
   "testConString": "mongodb://localhost:27017/wikimonitor-test",

--- a/conf/config.json.example
+++ b/conf/config.json.example
@@ -8,6 +8,11 @@
   "cap_total_size": 3000000000,
   "conString": "mongodb://localhost:27017/wikimonitor",
 
+  "//": "WebSocket server configuration, for directly accessing editlog.js events.",
+  "wsConfig": {
+      "port": 8082
+  },
+
   "//": "For unit testing (WILL BE DROPPED AND RECREATED)",
   "testConString": "mongodb://localhost:27017/wikimonitor-test",
 

--- a/editlog.js
+++ b/editlog.js
@@ -51,10 +51,12 @@ var connector = new modules.Persistence.MongoConnector(config.conString)
 persister = new modules.Persistence.PeriodicPersister(emitter, connector),
   editDataTracker = new modules.EditLog.EditDataTracker(emitter),
   associationTracker = new modules.Analytics.AssociationTracker(emitter, connector),
+  fieldTracker = new modules.Analytics.SocketFieldTracker(emitter, connector),
   editLog = new modules.EditLog.EditLog(config, emitter);
 
 persister.startMonitoring();
 editDataTracker.startMonitoring();
 associationTracker.startMonitoring();
+fieldTracker.startMonitoring();
 
 editLog.start();

--- a/editlog.js
+++ b/editlog.js
@@ -52,11 +52,13 @@ persister = new modules.Persistence.PeriodicPersister(emitter, connector),
   editDataTracker = new modules.EditLog.EditDataTracker(emitter),
   associationTracker = new modules.Analytics.AssociationTracker(emitter, connector),
   fieldTracker = new modules.Analytics.SocketFieldTracker(emitter, connector),
+  eventServer = new modules.EditLog.EventServer(config.wsConfig, emitter),
   editLog = new modules.EditLog.EditLog(config, emitter);
 
 persister.startMonitoring();
 editDataTracker.startMonitoring();
 associationTracker.startMonitoring();
 fieldTracker.startMonitoring();
+eventServer.startServer();
 
 editLog.start();

--- a/jade_templates/includes/dashboard.css
+++ b/jade_templates/includes/dashboard.css
@@ -15,6 +15,19 @@
     cursor:pointer;
 }
 
+#add_graph {
+    margin: 10px;
+    width:400px;
+}
+#add_graph fieldset {
+    padding-top:0;
+}
+#add_graph .form_field {
+    margin: 6px;
+}
+#add_graph .form_field label {
+    margin-right: 5px;
+}
 .chart {
     display: inline-block;
 }

--- a/jade_templates/includes/dashboard.css
+++ b/jade_templates/includes/dashboard.css
@@ -16,8 +16,10 @@
 }
 
 #add_graph {
+    vertical-align: top;
     margin: 10px;
-    width:400px;
+    width:40%;
+    display:inline-block;
 }
 #add_graph fieldset {
     padding-top:0;
@@ -27,6 +29,14 @@
 }
 #add_graph .form_field label {
     margin-right: 5px;
+}
+#rolling_log {
+    vertical-align: top;
+    display: inline-block;
+    width:50%;
+}
+#rolling_log .log_area {
+    font-size: 12px;
 }
 .chart {
     display: inline-block;

--- a/jade_templates/includes/dashboard.jade
+++ b/jade_templates/includes/dashboard.jade
@@ -23,6 +23,10 @@ form#add_graph
                 each val, index in fieldList || []
                     option(value=val)=val
         input(id="create_graph_button",type="button",value="Create Graph")
+
+div#rolling_log(data-ws-url=wsUrl,data-ws-config=wsUiConfig)
+    h3 Live Log Events
+    div.log_area
 div#main_graph_area
 
 script

--- a/jade_templates/includes/dashboard.jade
+++ b/jade_templates/includes/dashboard.jade
@@ -4,14 +4,26 @@ style
 h1 Wikiedit Monitor Dashboard
 nav#top_nav
   a(href="/?errorlog=1") Error Log
+form#add_graph
+    fieldset
+        h3 Graph Builder
+        div.form_field
+            label(for="GraphType") Graph Type
+            select(id="GraphType",name="GraphType")
+                option(value="ChangesGraph") ChangesGraph
+        div.form_field
+            label(for="XTitle") X-Axis Title
+            input(id="XTitle",name="XTitle",value="Logged in Last 24 Hours")
+        div.form_field
+            label(for="YTitle") Y-Axis Title
+            input(id="YTitle",name="YTitle")
+        div.form_field
+            label(for="fieldPath") Field Path
+            select(id="fieldPath",name="fieldPath")
+                each val, index in fieldList || []
+                    option(value=val)=val
+        input(id="create_graph_button",type="button",value="Create Graph")
 div#main_graph_area
-  div#active_articles.chart
-  div#active_users.chart
-  div#active_action_types.chart
-  div#active_comments.chart
-  div#socket_graph
-  div#edit_graph
-  div#error_graph
 
 script
    include dashboard.js

--- a/jade_templates/includes/dashboard.js
+++ b/jade_templates/includes/dashboard.js
@@ -1,4 +1,5 @@
 function DataPublisher(config, subscribers) {
+    this._urlParser = document.createElement('a');
     this._url = config.url;
     this._timeout = config.timeout;
     this._subscribers = subscribers || [];
@@ -16,15 +17,29 @@ DataPublisher.prototype._notifySubscribers = function(data){
 
 DataPublisher.prototype.startPolling = function(){
     var that = this;
-    d3.json(this._url, function(error, data){
-        if( ! error) {
-            that._notifySubscribers(data);
-        }
+    var endTime = ((new Date()).getTime()/1000).toFixed(0);
+    var startTime = endTime - (60*60); // minus one hour
 
-        setTimeout(function(){
-            that.startPolling();
-        }, that._timeout);
-    });
+    var urlPrefix;
+    if(this._url.indexOf('?') === -1) {
+        urlPrefix = '?'
+    } else {
+        urlPrefix = '&'
+    }
+    d3.json(
+        this._url + urlPrefix
+            + 'time_start=' + startTime
+            + '&time_end=' + endTime,
+        function(error, data){
+            if( ! error) {
+                that._notifySubscribers(data);
+            }
+
+            setTimeout(function(){
+                that.startPolling();
+            }, that._timeout);
+        }
+    );
 };
 
 function ChangesGraph(containerId, fieldTitle, rawFieldName, fieldFunction) {

--- a/lookup.js
+++ b/lookup.js
@@ -58,9 +58,16 @@ function handleRequest(request, res) {
       });
   }
 
-  function renderJsonResponse(jsObj) {
+  function renderJsonResponse(err, jsObj, statusCode) {
     res.setHeader('Content-Type', 'application/json');
-    res.send(JSON.stringify(jsObj));
+    var body = '';
+    if (err) {
+      res.status(statusCode || 500);
+      body = jsObj || { error: ((typeof err.toString === 'function') ? err.toString() : err) };
+    } else {
+      body = jsObj || { success: true };
+    }
+    res.send(body);
   }
 
   var context = {
@@ -69,7 +76,13 @@ function handleRequest(request, res) {
     db: wikiDb
   };
 
-  modules.Lookup.DiffSearch(context, renderSimpleTemplate, error) || modules.Lookup.TitleSearch(context, renderSimpleTemplate, error) || modules.Lookup.ErrorLog(context, renderSimpleTemplate, error) || modules.Lookup.ErrorLog.ajaxCall(context, renderJsonResponse, error) || modules.Lookup.Dashboard(context, renderSimpleTemplate, error) || modules.Lookup.Dashboard.ajaxCall(context, renderJsonResponse, error) || error('Oops, that page does not exist.');
+  modules.Lookup.DiffSearch(context, renderSimpleTemplate, error)
+    || modules.Lookup.TitleSearch(context, renderSimpleTemplate, error) 
+    || modules.Lookup.ErrorLog(context, renderSimpleTemplate, error) 
+    || modules.Lookup.ErrorLog.ajaxCall(context, renderJsonResponse) 
+    || modules.Lookup.Dashboard(context, renderSimpleTemplate, error) 
+    || modules.Lookup.Dashboard.ajaxCall(context, renderJsonResponse) 
+    || error('Oops, that page does not exist.');
 }
 
 //Create a server

--- a/lookup.js
+++ b/lookup.js
@@ -71,6 +71,7 @@ function handleRequest(request, res) {
   }
 
   var context = {
+    config: config,
     url: urlObject,
     wiki: wiki,
     db: wikiDb

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "async": "^1.5.2",
     "auto-loader": "^0.2.0",
     "bower": "^1.7.7",
+    "bufferutil": "^1.2.1",
     "cheerio": "^0.20.0",
     "dateformat": "^1.0.12",
     "debounce": "^1.0.0",
@@ -16,7 +17,9 @@
     "socket.io": "0.9.x",
     "sprintf": "^0.1.5",
     "sprintf-js": "^1.0.3",
-    "vows": "^0.8.1"
+    "utf-8-validate": "^1.2.1",
+    "vows": "^0.8.1",
+    "ws": "^1.1.0"
   },
   "scripts": {
     "start": "node editlog.js",

--- a/src/Analytics/SocketFieldTracker.js
+++ b/src/Analytics/SocketFieldTracker.js
@@ -8,6 +8,7 @@ function getObjectProps(obj, prefix) {
   var keyList = Object.keys(obj).map((s) => prefix + s);
   for(var n of Object.keys(obj)) {
     if(obj[n] && obj[n].toString && obj[n].toString() === '[object Object]') {
+      delete keyList[keyList.indexOf(n)];
       Array.prototype.push.apply(keyList, getObjectProps(obj[n], prefix + n));
     }
   }

--- a/src/Analytics/SocketFieldTracker.js
+++ b/src/Analytics/SocketFieldTracker.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const EVENTS = require('../EditLog/EventDefinitions.js'),
+  PERSISTENCE_EVENTS = require('../Persistence/EventDefinitions.js');
+
+function getObjectProps(obj, prefix) {
+  prefix = (prefix ? (prefix + '.') : '');
+  var keyList = Object.keys(obj).map((s) => prefix + s);
+  for(var n of Object.keys(obj)) {
+    if(obj[n] && obj[n].toString && obj[n].toString() === '[object Object]') {
+      Array.prototype.push.apply(keyList, getObjectProps(obj[n], prefix + n));
+    }
+  }
+  return keyList;
+}
+
+var trackers = new WeakMap();
+class SocketFieldTracker {
+  constructor(emitter, connector) {
+    trackers.set(this, {
+      emitter: emitter,
+      connector: connector,
+      propsSent: [],
+      monitoring: false
+    });
+  }
+  startMonitoring() {
+    var opts = trackers.get(this),
+      emitter = opts.emitter,
+      connector = opts.connector,
+      propsSent = opts.propsSent;
+
+    var saveSocketMessage;
+    emitter.on(EVENTS.socketdata, saveSocketMessage = function(message) {
+      var props = getObjectProps(message);
+
+      // Prevent unnecessary upserts w/caching
+      var diffProps = props.filter((s) => propsSent.indexOf(s) === -1);
+      if(diffProps.length < 1) return;
+
+      connector.withMongoConnection(function(err, db) {
+        if (err) return console.log('error trying connecting to database');
+
+        diffProps.forEach(function(fieldPath) {
+          db.collection('socketdata_fields').update({
+              field_path: fieldPath
+            }, {
+              $setOnInsert: {
+                field_path: fieldPath,
+                first_detected_message: message
+              }
+            }, {
+              upsert: true
+            },
+            function(err) {
+              if(err) console.log(err);
+              else propsSent.push(fieldPath);
+            }
+          );
+        });
+      });
+    });
+    opts.monitoring = true;
+    opts.listeners = {
+      socketdata: saveSocketMessage
+    };
+  }
+  stopMonitoring() {
+    var opts = trackers.get(this),
+      emitter = opts.emitter,
+      listeners = opts.listeners;
+
+    if (opts.monitoring) {
+      throw Error('Cannot stop monitoring when you\'re not monitoring.');
+    }
+
+    emitter.removeListener(EVENTS.socketdata, listeners.socketdata);
+
+    opts.monitoring = false;
+    delete opts.listeners;
+  }
+}
+module.exports = SocketFieldTracker;

--- a/src/EditLog/EventServer.js
+++ b/src/EditLog/EventServer.js
@@ -1,0 +1,202 @@
+"use strict";
+
+const LISTEN_TIME_MAX = 300000, // 5 minutes
+      LISTEN_TIME_MIN = 250, // 0.25 seconds
+      EVENTS = require('../EditLog/EventDefinitions.js'),
+      PERSISTENCE_EVENTS = require('../Persistence/EventDefinitions.js'),
+      WebSocketServer = require('ws').Server;
+
+var server = new WeakMap();
+class EventServer {
+    constructor(wsConfig, emitter) {
+        if(typeof wsConfig !== 'object') {
+            throw new Error('EventServer requires an object as its first parameter '
+                    + 'to configure the websocket server. See https://github.com/websockets/ws for details.');
+        }
+
+        server.set(this, {
+            wsConfig: wsConfig,
+            ws: undefined,
+            emitter: emitter,
+            listeners: {},
+            clients: [],
+            started: false
+        });
+    }
+    startServer() {
+        var state = server.get(this);
+        if(state.started) {
+            throw new Error('WebSocket server already started.');
+        }
+        var wss = new WebSocketServer(state.wsConfig);
+        wss.on('connection', function(ws) {
+            var config = {
+                timeout: 1000,
+                editLogEvents: {},
+                persistenceEvents: {}
+            };
+            var subState = {
+                timeout: undefined,
+                editLogEventFunctions: {},
+                persistenceEventFunctions: {}
+            };
+
+            function sendEvent(type, data) {
+                ws.send(JSON.stringify({
+                    eventType: type,
+                    data: data
+                }));
+            }
+
+            ws.on('open', function(){
+                // Bind edit log events
+                for(var lev of Object.keys(config.editLogEvents)){
+                    if(! (lev in subState.editLogEventFunctions)) {
+                        var levFunc = sendEvent.bind(null, lev);
+                        subState.editLogEventFunctions[lev] = levFunc;
+                        state.emitter.on(EVENTS[lev], levFunc);
+                    }
+                }
+
+                // Bind persistence events
+                for(var pev of Object.keys(config.persistenceEvents)){
+                    if( ! (pev in subState.persistenceEventFunctions)) {
+                        var pevFunc = sendEvent.bind(null, pev);
+                        subState.persistenceEventFunctions[pev] = pevFunc;
+                        state.emitter.on(PERSISTENCE_EVENTS[pev], pevFunc);
+                    }
+                }
+            });
+
+            ws.on('close', function(){
+                // Unbind edit log events
+                for(var olev of Object.keys(subState.editLogEventFunctions)) {
+                    var folev = subState.editLogEventFunctions[olev];
+                    state.emitter.removeListener(EVENTS[olev], folev);
+                    delete subState.editLogEventFunctions[olev];
+                }
+
+                // Unbind persistence events
+                for(var opev of Object.keys(subState.persistenceEventFunctions)) {
+                    var fopev = subState.persistenceEventFunctions[opev];
+                    state.emitter.removeListener(PERSISTENCE_EVENTS[opev], fopev);
+                    delete subState.persistenceEventFunctions[opev];
+                }
+            });
+
+            ws.on('message', function(rawMessage){
+                var message = JSON.parse(rawMessage);
+                if( ! (message && 'type' in message)) {
+                    ws.send(JSON.stringify({ status: 'error', description: 'missing message content or type' }));
+                    return;
+                }
+
+                switch(message.type) {
+                    case 'config':
+                        if( ! ('config' in message && typeof message.config === 'object')) {
+                            ws.send(JSON.stringify({ status: 'error', description: 'unsupported message type' }));
+                            return;
+                        }
+
+                        // Validate and set timeout field from client-provided configuration
+                        if('timeout' in message.config) {
+                            var newTimeout = parseInt(message.config.timeout);
+                            if(newTimeout > LISTEN_TIME_MAX || newTimeout < LISTEN_TIME_MIN) {
+                                ws.send(JSON.stringify({
+                                    status: 'error',
+                                    description: 'timeout must be less than ' + LISTEN_TIME_MAX
+                                        + ' and greater than ' + LISTEN_TIME_MIN
+                                }));
+                                return;
+                            } else {
+                                config.timeout = newTimeout;
+                            }
+                        }
+
+                        // Validate and set edit log events to send from client-provided configuration
+                        if('editLogEvents' in message.config) {
+                            if(typeof message.config.editLogEvents === 'object') {
+                                config.editLogEvents = message.config.editLogEvents;
+                            } else {
+                                ws.send(JSON.stringify({
+                                    status: 'error',
+                                    description: 'editLogEvents must be an object'
+                                }));
+                                return;
+                            }
+                        }
+
+                        // Validate and set persistence events to send from client-provided configuration
+                        if('persistenceEvents' in message.config) {
+                            if(typeof message.config.persistenceEvents === 'object') {
+                                config.persistenceEvents = message.config.persistenceEvents;
+                            } else {
+                                ws.send(JSON.stringify({
+                                    status: 'error',
+                                    description: 'persistenceEvents must be an object'
+                                }));
+                                return;
+                            }
+                        }
+
+                        // Bind newly configured events
+                        for(var lev of Object.keys(config.editLogEvents)){
+                            if(! (lev in subState.editLogEventFunctions)) {
+                                var levFunc = sendEvent.bind(null, lev);
+                                subState.editLogEventFunctions[lev] = levFunc;
+                                state.emitter.on(EVENTS[lev], levFunc);
+                            }
+                        }
+
+                        // Unbind events that are no longer configured
+                        for(var olev of Object.keys(subState.editLogEventFunctions)) {
+                            if(! (olev in config.editLogEvents)) {
+                                var folev = subState.editLogEventFunctions[olev];
+                                state.emitter.removeListener(EVENTS[olev], folev);
+                                delete subState.editLogEventFunctions[olev];
+                            }
+                        }
+
+                        // Bind newly configured persistence events
+                        for(var pev of Object.keys(config.persistenceEvents)){
+                            if( ! (pev in subState.persistenceEventFunctions)) {
+                                var pevFunc = sendEvent.bind(null, pev);
+                                subState.persistenceEventFunctions[pev] = pevFunc;
+                                state.emitter.on(PERSISTENCE_EVENTS[pev], pevFunc);
+                            }
+                        }
+
+                        // Unbind persistence events that are no longer configured
+                        for(var opev of Object.keys(subState.persistenceEventFunctions)) {
+                            if(! (opev in config.editLogEvents)) {
+                                var fopev = subState.persistenceEventFunctions[opev];
+                                state.emitter.removeListener(PERSISTENCE_EVENTS[opev], fopev);
+                                delete subState.persistenceEventFunctions[opev];
+                            }
+                        }
+
+                        ws.send(JSON.stringify({
+                            status: 'success'
+                        }));
+                        break;
+                    default:
+                        ws.send(JSON.stringify({ status: 'error', description: 'unsupported message type' }));
+                        return;
+                }
+            });
+        });
+        state.started = true;
+        state.ws = wss;
+    }
+    stopServer() {
+        var state = server.get(this);
+        if( ! state.started) {
+            throw new Error('WebSocket server not yet started.');
+        }
+        state.ws.close();
+        delete state.ws;
+        state.started = false;
+    }
+}
+
+module.exports = EventServer;

--- a/src/EditLog/InitDb.js
+++ b/src/EditLog/InitDb.js
@@ -132,6 +132,15 @@ function InitDb(config) {
     },
 
     function(callback) {
+      var collection = 'socketdata';
+      var index = {
+        'message.timestamp': 1,
+        'message.wiki': 1
+      };
+      createCollectionIndex(collection, index, callback);
+    },
+
+    function(callback) {
       var collection = 'wikiedits';
       var index = {
         'revnew': 1,

--- a/src/Lookup/Dashboard.js
+++ b/src/Lookup/Dashboard.js
@@ -9,6 +9,8 @@ function dashboardView(cxt, callback, errorCb) {
           return;
         }
         callback('dashboard.jade', {
+            wsUrl: cxt.config.wsUrl,
+            wsUiConfig: cxt.config.wsUiConfig,
             fieldList: data.map((d) => d.field_path)
         });
       });

--- a/src/Lookup/Dashboard.js
+++ b/src/Lookup/Dashboard.js
@@ -9,19 +9,32 @@ function dashboardView(cxt, callback) {
 
 dashboardView.ajaxCall = function(cxt, callback, errorCallback) {
   if (cxt.url.query.dash_socketdata) {
-    var wiki = cxt.wiki;
-    var db = cxt.db;
-    db.collection('socketdata_last_hour')
-      .find({
-        'message.wiki': wiki + 'wiki'
-      })
-      .toArray(function(error, data) {
-        if (error) errorCallback(error);
-        callback({
-          wiki: wiki,
-          data: data
-        });
-      });
+    if(
+        cxt.url.query.time_start
+        && cxt.url.query.time_end
+    ) {
+        var wiki = cxt.wiki;
+        var db = cxt.db;
+        db.collection('socketdata')
+          .find({
+            'message.timestamp': {
+                $lt: parseInt(cxt.url.query.time_end),
+                $gte: parseInt(cxt.url.query.time_start)
+            },
+            'message.wiki': wiki + 'wiki'
+          })
+          .toArray(function(error, data) {
+            if (error) errorCallback(error);
+            callback(null, {
+              wiki: wiki,
+              data: data
+            });
+          });
+    } else {
+        var err = new Error('time_start and time_end query parameters are required');
+        callback(err, undefined, 422);
+        return true;
+    }
     return true;
   }
   return false;

--- a/src/Lookup/Dashboard.js
+++ b/src/Lookup/Dashboard.js
@@ -1,6 +1,17 @@
-function dashboardView(cxt, callback) {
+function dashboardView(cxt, callback, errorCb) {
   if (Object.keys(cxt.url.query).length < 1) {
-    callback('dashboard.jade', {});
+    var db = cxt.db;
+    db.collection('socketdata_fields')
+      .find()
+      .toArray(function(error, data) {
+        if(error) {
+          errorCb(error);
+          return;
+        }
+        callback('dashboard.jade', {
+            fieldList: data.map((d) => d.field_path)
+        });
+      });
     return true;
   } else {
     return false;

--- a/src/Lookup/ErrorLog.js
+++ b/src/Lookup/ErrorLog.js
@@ -16,7 +16,7 @@ function errorView(cxt, callback) {
   }
 }
 
-errorView.ajaxCall = function(cxt, callback, errorCallback) {
+errorView.ajaxCall = function(cxt, callback) {
   // TODO: Use aggregate function
   /*
   db.getCollection('errorlog').aggregate([
@@ -120,7 +120,8 @@ errorView.ajaxCall = function(cxt, callback, errorCallback) {
     }
   }]).toArray(function(err, errorRows) {
     if (err) {
-      return errorCallback("db error: " + err);
+      callback(err, undefined, 500);
+      return;
     }
 
     var revTitleList = [];
@@ -149,7 +150,8 @@ errorView.ajaxCall = function(cxt, callback, errorCallback) {
       }]
     ).toArray(function(err, countRows) {
       if (err) {
-        return errorCallback("db error: " + err);
+        callback(err, undefined, 500);
+        return;
       }
 
       var oCountsByTitle = {};
@@ -214,7 +216,7 @@ errorView.ajaxCall = function(cxt, callback, errorCallback) {
             return;
           }
 
-          callback({
+          callback(null, {
             wiki: wiki,
             start: start,
             length: length,


### PR DESCRIPTION
@leebradley This adds a live event display to the dashboard for Wikipedia API responses, and it allows us to push other events to the UI as well. This adds a WebSocket server directly into `editlog.js`.

This merge request includes #31.
