### PR TITLE
Delayed purging for reserved revisions until they're released

### DIFF
--- a/src/EditLog/EditLog.js
+++ b/src/EditLog/EditLog.js
@@ -49,7 +49,9 @@ function EditLog(config, m_eventEmitter) {
     m_revisionList.releaseRevision(revid);
 
     // Strikes until I'm not querying for this revision's diff anymore
-    if (m_revisionList.getReleaseCount(revid) > MAX_NOTCACHED_RETRIES) {
+    if ( ! m_revisionList.hasRevision(revid)) {
+      logError(revid, "Article deleted, and last revision query attempt failed: " + strError, page, strUrl, false);
+    } else if (m_revisionList.getReleaseCount(revid) > MAX_NOTCACHED_RETRIES) {
       // Something's wrong with this revision! :(
       // NOTE: Usually happens with an admin's revdelete revision
       // EX: https://en.wikipedia.org/w/api.php?action=query&prop=revisions&format=json&rvdiffto=prev&revids=696894315
@@ -193,8 +195,8 @@ function EditLog(config, m_eventEmitter) {
 
       if (oRev && oRev.title === strTitle) {
         deletedRevisions.push(oRev);
-        logError(revid, "Revision could not be queried because article was deleted", oRev, "", false);
-        m_revisionList.purgeRevision(revid);
+        logError(revid, "Revision query may fail because article was deleted", oRev, "", false);
+        m_revisionList.purgeOnRelease(revid);
         iRevsDeleted++;
       }
     }

--- a/src/EditLog/RevisionList.js
+++ b/src/EditLog/RevisionList.js
@@ -6,7 +6,8 @@ class RevisionList {
       revisions: [],
       reservedRevisions: [],
       dataByRevId: {},
-      releaseCountByRevId: {}
+      releaseCountByRevId: {},
+      purgeOnRelease: []
     });
   }
   get count() {
@@ -23,6 +24,10 @@ class RevisionList {
     var od = revLists.get(this);
     od.revisions.push(revId);
     od.dataByRevId[revId] = data;
+  }
+  hasRevision(revId) {
+    revId = parseInt(revId);
+    return this.revisions.indexOf(revId) !== -1;
   }
   getRevisionData(revId) {
     revId = parseInt(revId);
@@ -57,12 +62,25 @@ class RevisionList {
         od.releaseCountByRevId[revId] = 1;
       }
     }
+    if(od.purgeOnRelease[revId]) {
+       this.purgeRevision(revId);
+    }
+  }
+  purgeOnRelease(revId) {
+    revId = parseInt(revId);
+    var od = revLists.get(this);
+    if(od.revisions.indexOf(revId) === -1){
+       od.purgeOnRelease[revId] = true;
+    } else {
+       this.purgeRevision(revId);
+    }
   }
   purgeRevision(revId) {
     revId = parseInt(revId);
     var od = revLists.get(this);
     delete od.dataByRevId[revId];
     delete od.releaseCountByRevId[revId];
+    delete od.purgeOnRelease[revId];
 
     var reservedIndex = od.reservedRevisions.indexOf(revId);
     if (reservedIndex !== -1) {


### PR DESCRIPTION
@leebradley Please review.

This addresses #35 by deferring revision purging until the revision is released (i.e. after Wikipedia's API comes back with a response and we've mostly processed it).
